### PR TITLE
Usability improvements

### DIFF
--- a/src/bc-authorizer-content.js
+++ b/src/bc-authorizer-content.js
@@ -27,7 +27,7 @@ export class BcAuthorizerContent extends LitElement {
 
     return html`
       <div>${
-        Object.keys(facts_map).map(function(key, index) {
+        Object.keys(facts_map).sort().map(function(key, index) {
 
           return html`<table><thead><tr><th>${key}</th></tr></thead><tbody>
             ${facts_map[key].map((terms) => {

--- a/src/bc-datalog-editor.js
+++ b/src/bc-datalog-editor.js
@@ -144,6 +144,7 @@ export class BcDatalogEditor extends LitElement {
 
   static get properties () {
     return {
+      readonly: { type: Boolean },
       datalog: { type: String },
       parseErrors: { type: Array },
       markers: { type: Array },
@@ -152,6 +153,7 @@ export class BcDatalogEditor extends LitElement {
 
   constructor () {
     super();
+    this.readonly = this.readonly === true;
     this.parseErrors = [];
     this.markers = [];
   }
@@ -178,6 +180,7 @@ export class BcDatalogEditor extends LitElement {
           basicSetup,
           lineNumbers(),
           history(),
+          EditorView.editable.of(!this.readonly),
           keymap.of([...defaultKeymap, ...historyKeymap]),
           updateListenerExtension,
           StreamLanguage.define(biscuit_mode),

--- a/src/bc-token-printer.js
+++ b/src/bc-token-printer.js
@@ -84,6 +84,7 @@ export class BcTokenPrinter extends LitElement {
               <p>Block ${index}:</p>
               <bc-datalog-editor
                 datalog=${block.code}
+                readonly="true"
                 @bc-datalog-editor:update="${(e) => { this._onUpdatedCode(block, e.detail.code) }}"}>
               </bc-datalog-editor>
               </div>


### PR DESCRIPTION
- datalog blocks are now readonly in the token printer
- facts are now displayed always in the same order (to avoid facts jumping up and down when editing datalog