### PR TITLE
Make token printer editable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,5 @@
+{ pkgs ? import <nixpkgs> {}}: with pkgs;
+
+mkShell {
+  buildInputs = [ nodejs ];
+}

--- a/src/bc-authorizer-content.js
+++ b/src/bc-authorizer-content.js
@@ -1,4 +1,4 @@
-import { css, html, LitElement } from 'lit-element';
+import { css, html, LitElement } from 'lit';
 
 /**
  * TODO DOCS

--- a/src/bc-authorizer-editor.js
+++ b/src/bc-authorizer-editor.js
@@ -1,4 +1,4 @@
-import { css, html, LitElement } from 'lit-element';
+import { css, html, LitElement } from 'lit';
 import './bc-datalog-editor.js';
 import { dispatchCustomEvent } from '../src/lib/events.js';
 

--- a/src/bc-authorizer-result.js
+++ b/src/bc-authorizer-result.js
@@ -1,4 +1,4 @@
-import { css, html, LitElement } from 'lit-element';
+import { css, html, LitElement } from 'lit';
 
 /**
  * TODO DOCS

--- a/src/bc-datalog-editor.js
+++ b/src/bc-datalog-editor.js
@@ -1,4 +1,4 @@
-import { css, html, LitElement } from 'lit-element';
+import { css, html, LitElement } from 'lit';
 import { dispatchCustomEvent } from '../src/lib/events.js';
 
 import {keymap, EditorView, Range, Decoration} from "@codemirror/view"

--- a/src/bc-token-content.js
+++ b/src/bc-token-content.js
@@ -1,4 +1,4 @@
-import { css, html, LitElement } from 'lit-element';
+import { css, html, LitElement } from 'lit';
 
 /**
  * TODO DOCS

--- a/src/bc-token-editor.js
+++ b/src/bc-token-editor.js
@@ -1,4 +1,4 @@
-import { css, html, LitElement } from 'lit-element';
+import { css, html, LitElement } from 'lit';
 import './bc-datalog-editor.js';
 import { dispatchCustomEvent } from '../src/lib/events.js';
 

--- a/src/lint.css.js
+++ b/src/lint.css.js
@@ -1,5 +1,5 @@
 // language=CSS
-import { css } from 'lit-element';
+import { css } from 'lit';
 
 export const codemirrorLinkStyles = css`
   /* The lint marker gutter */


### PR DESCRIPTION
This lets people paste encoded tokens to inspect them, instead of just taking them as an attribute.

There was some refactoring as well (datalog edit handlers are gone for now)