### PR TITLE
Add datalog playground

### DIFF
--- a/src/bc-datalog-playground.ts
+++ b/src/bc-datalog-playground.ts
@@ -3,7 +3,7 @@ import { customElement, property, state } from "lit/decorators.js";
 import "./bc-datalog-editor.js";
 import { initialize } from "./wasm.js";
 import { execute } from "@biscuit-auth/biscuit-wasm-support";
-import { convertMarker } from "./markers";
+import { convertMarker, convertError } from "./markers";
 
 /**
  * TODO DOCS
@@ -32,6 +32,7 @@ export class BCDatalogPlayground extends LitElement {
   render() {
     let markers = [];
     let authorizer_world = [];
+    let parseErrors = [];
     if (this.started) {
       const authorizerQuery = {
         token_blocks: [],
@@ -41,12 +42,14 @@ export class BCDatalogPlayground extends LitElement {
       const authorizerResult = execute(authorizerQuery);
       authorizer_world = authorizerResult.authorizer_world;
       markers = authorizerResult.authorizer_editor.markers.map(convertMarker);
+      parseErrors = authorizerResult.authorizer_editor.errors.map(convertError);
     }
 
     return html`
       <bc-authorizer-editor
         code=${this.code}
         markers=${JSON.stringify(markers)}
+        parseErrors=${JSON.stringify(parseErrors)}
         @bc-authorizer-editor:update=${this.onUpdatedCode}
         }
       >

--- a/src/bc-datalog-playground.ts
+++ b/src/bc-datalog-playground.ts
@@ -1,0 +1,60 @@
+import { html, LitElement } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import "./bc-datalog-editor.js";
+import { initialize } from "./wasm.js";
+import { execute } from "@biscuit-auth/biscuit-wasm-support";
+import { convertMarker } from "./markers";
+
+/**
+ * TODO DOCS
+ */
+@customElement("bc-datalog-playground")
+export class BCDatalogPlayground extends LitElement {
+  @property() code = "";
+  @state() private started = false;
+
+  constructor() {
+    super();
+    const codeChild = this.querySelector("code");
+    if (codeChild !== null) {
+      this.code = codeChild.textContent?.trim() ?? "";
+    }
+  }
+
+  firstUpdated() {
+    initialize().then(() => (this.started = true));
+  }
+
+  onUpdatedCode(e: { detail: { code: string } }) {
+    this.code = e.detail.code;
+  }
+
+  render() {
+    let markers = [];
+    let authorizer_world = [];
+    if (this.started) {
+      const authorizerQuery = {
+        token_blocks: [],
+        authorizer_code: this.code,
+        query: "",
+      };
+      const authorizerResult = execute(authorizerQuery);
+      authorizer_world = authorizerResult.authorizer_world;
+      markers = authorizerResult.authorizer_editor.markers.map(convertMarker);
+    }
+
+    return html`
+      <bc-authorizer-editor
+        code=${this.code}
+        markers=${JSON.stringify(markers)}
+        @bc-authorizer-editor:update=${this.onUpdatedCode}
+        }
+      >
+      </bc-authorizer-editor>
+      Facts:
+      <bc-authorizer-content
+        content="${JSON.stringify(authorizer_world)}"
+      ></bc-authorizer-content>
+    `;
+  }
+}

--- a/src/bc-token-printer.ts
+++ b/src/bc-token-printer.ts
@@ -3,7 +3,7 @@ import { customElement, property, state } from "lit/decorators.js";
 import "./bc-datalog-editor.js";
 import { initialize } from "./wasm.js";
 import { execute, parse_token } from "@biscuit-auth/biscuit-wasm-support";
-import { LibMarker } from "./types";
+import { LibMarker, convertMarker } from "./markers";
 
 /**
  * TODO DOCS
@@ -119,19 +119,6 @@ export class BcTokenPrinter extends LitElement {
     `;
   }
 
-  convertMark(marker: LibMarker) {
-    return {
-      from: {
-        line: marker.position.line_start,
-        ch: marker.position.column_start,
-      },
-      to: { line: marker.position.line_end, ch: marker.position.column_end },
-      start: marker.position.start,
-      end: marker.position.end,
-      ok: marker.ok,
-    };
-  }
-
   renderAuthorizer(markers: Array<LibMarker>, result: string) {
     if (!this.showAuthorizer) return;
 
@@ -140,7 +127,7 @@ export class BcTokenPrinter extends LitElement {
         <p>Authorizer</p>
         <bc-authorizer-editor
           code="${this.authorizer}"
-          markers="${JSON.stringify(markers.map(this.convertMark))}"
+          markers="${JSON.stringify(markers.map(convertMarker))}"
           @bc-authorizer-editor:update=${this._onUpdatedAuthorizer}
         >
         </bc-authorizer-editor>
@@ -167,7 +154,7 @@ export class BcTokenPrinter extends LitElement {
     };
     const authorizerResult = execute(authorizerQuery);
     const blockMarkers = authorizerResult.token_blocks.map(
-      (b: { markers: Array<LibMarker> }) => b.markers.map(this.convertMark)
+      (b: { markers: Array<LibMarker> }) => b.markers.map(convertMarker)
     );
 
     return html`

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import "./bc-authorizer-content.js";
 import "./bc-authorizer-example.js";
 import "./bc-datalog-example.js";
 import "./bc-token-printer";
+import "./bc-datalog-playground";
 import "./bc-full-example.js";
 export { execute } from "@biscuit-auth/biscuit-wasm-support";
 export { initialize } from "./wasm.js";

--- a/src/markers.ts
+++ b/src/markers.ts
@@ -30,3 +30,18 @@ export const convertMarker = (marker: LibMarker) => {
     ok: marker.ok,
   };
 };
+
+export type LibError = {
+  message: string;
+  position: { start: number; end: number; line_start: number };
+};
+
+export const convertError = (error: LibError) => {
+  return {
+    message: error.message,
+    severity: "error",
+    line_start: error.position.line_start,
+    from: error.position.start,
+    to: error.position.end,
+  };
+};

--- a/src/markers.ts
+++ b/src/markers.ts
@@ -17,3 +17,16 @@ export type CMMarker = {
   end: number;
   ok: boolean;
 };
+
+export const convertMarker = (marker: LibMarker) => {
+  return {
+    from: {
+      line: marker.position.line_start,
+      ch: marker.position.column_start,
+    },
+    to: { line: marker.position.line_end, ch: marker.position.column_end },
+    start: marker.position.start,
+    end: marker.position.end,
+    ok: marker.ok,
+  };
+};


### PR DESCRIPTION
This is a simpler alternative to `bc-datalog-example`, written from scratch in typescript, made to be used as is in the website.