### PR TITLE
per-theme success/failure highlights

### DIFF
--- a/src/bc-datalog-editor.js
+++ b/src/bc-datalog-editor.js
@@ -110,11 +110,11 @@ const markField = StateField.define({
 });
 
 const successMark = Decoration.mark({
-  attributes: { style: "background: rgb(193, 241, 193)" },
+  attributes: { style: "background: var(--success-background);" },
 });
 
 const failureMark = Decoration.mark({
-  attributes: { style: "background: rgb(255, 162, 162)" },
+  attributes: { style: "background: var(--failure-background);" },
 });
 
 const parseErrorMark = Decoration.mark({
@@ -259,6 +259,8 @@ export class BcDatalogEditor extends LitElement {
           :host {
             background: #131314;
             color: #dee2e6;
+            --success-background: rgba(0, 255, 0, 0.3);
+            --failure-background: rgba(255, 0, 0, 0.5);
           }
 
           .ͼ2 .cm-gutters {
@@ -304,6 +306,8 @@ export class BcDatalogEditor extends LitElement {
           :host {
             background: #fff;
             color: #1d2d35;
+            --success-background: rgb(193, 241, 193);
+            --failure-background: rgb(255, 162, 162);
           }
         }
       `,


### PR DESCRIPTION
Previously, the highlighting colors used to show failing checks / policies were hardcoded, with colors suited to the light theme. It made things hard to read when using the dark theme.

This PR uses different colors for the dark theme (i didn't spend much time searching for better colors, i just took something that looked okay).