### PR TITLE
Improve errors in bc-token-printer

### DIFF
--- a/src/bc-authorizer-result.ts
+++ b/src/bc-authorizer-result.ts
@@ -34,14 +34,21 @@ export class BcAuthorizerResult extends LitElement {
 
   renderResult() {
     const logicError = this.content?.Ok?.authorizer_result?.Err?.FailedLogic;
+    const parsingError = this.content?.Err?.token;
+    const publicKeyError = this.content?.Err?.root_key;
     const success = this.content?.Ok?.authorizer_result?.Ok !== undefined;
     if (success) {
       return html`<div><pre>Success</pre></div>`;
     } else if (logicError) {
       return this.renderLogicError(logicError);
+    } else if (publicKeyError) {
+      return html`<div><pre>Public key parsing error</pre></div>`;
+    } else if (parsingError) {
+      return html`<div><pre>Token parsing error</pre></div>`;
     } else if (this.content?.Err) {
       return html`<div><pre>Datalog execution error</pre></div>`;
     } else {
+      console.error(this.content);
       return html`<div><pre>Unknown error</pre></div>`;
     }
   }

--- a/src/bc-token-printer.ts
+++ b/src/bc-token-printer.ts
@@ -193,9 +193,21 @@ export class BcTokenPrinter extends LitElement {
       </div>
       <div class="content">
         <p>Result</p>
-        <bc-authorizer-result .content=${result}> </bc-authorizer-result>
+        ${this.renderAuthorizerResult(result)}
       </div>
     `;
+  }
+
+  renderAuthorizerResult(result: Result<AuthorizerResult, AuthorizerError>) {
+    if (this.biscuit === "") {
+      return html`<div><pre>Please enter a base64-encoded token</pre></div>`;
+    }
+    if (this.rootPublicKey === "") {
+      return html`<div><pre>Please enter a public key</pre></div>`;
+    }
+    return html`<bc-authorizer-result
+      .content=${result}
+    ></bc-authorizer-result>`;
   }
 
   renderExtraBlock(

--- a/src/lib/adapters.ts
+++ b/src/lib/adapters.ts
@@ -49,6 +49,8 @@ export type Result<A, E> = {
 export type AuthorizerError = {
   authorizer: Array<LibError>;
   blocks: Array<Array<LibError>>;
+  root_key?: string;
+  token?: string;
 };
 
 export type Fact = {


### PR DESCRIPTION
Don't display an error when no token or public key have been provided: tell the user what they need to enter next.

When the token or the public key is provided but unparseable, explain it to the user, instead of displaying "datalog execution error"