### PR TITLE
Highlight selected text

### DIFF
--- a/demo/playground.html
+++ b/demo/playground.html
@@ -20,6 +20,7 @@
   <code class="block">
 operation("read");
 resource("file1");
+operation("toto");
   </code>
   <code class="block" privateKey="ffca92f0d85740520ac27343ee563f0821e6c6fbc7a565e406687c894d67c912">
     group("admin");

--- a/src/bc-datalog-editor.ts
+++ b/src/bc-datalog-editor.ts
@@ -196,7 +196,7 @@ export class BcDatalogEditor extends LitElement {
       } while (res !== -1);
     }
 
-    const rendered = this.renderText2(
+    const rendered = this.renderText(
       this.code,
       this._captures,
       this.marks,
@@ -227,7 +227,7 @@ ${this.code}</textarea
     </div>`;
   }
 
-  renderText2(
+  renderText(
     text: string,
     captures: Range[],
     marks: Range[],


### PR DESCRIPTION
This adds a feature from the legacy editor: when selecting a bit of text, all matching occurrences are highlighted. This is especially useful when checking unification in datalog.